### PR TITLE
Download results concurrently with scanning

### DIFF
--- a/go/config.go
+++ b/go/config.go
@@ -23,6 +23,7 @@ package athenadriver
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -157,6 +158,10 @@ func (c *Config) SetOutputBucket(o string) error {
 	return nil
 }
 
+func (c *Config) SetScratchDir(d string) {
+	c.values.Set("scratchDir", d)
+}
+
 // SetRegion is to set region.
 func (c *Config) SetRegion(o string) error {
 	if len(o) == 0 {
@@ -288,6 +293,17 @@ func (c *Config) GetQueryResultKey(qid string) string {
 	}
 
 	return fmt.Sprintf("%s.csv", strings.Join(key, "/"))
+}
+
+// GetScratchDir returns the directory where results will be downloaded. If not
+// set the system temporary directory will be returned.
+func (c *Config) GetScratchDir() string {
+	dir := c.values.Get("scratchDir")
+	if dir != "" {
+		return dir
+	}
+
+	return os.TempDir()
 }
 
 // GetWorkgroup is getter of Workgroup.

--- a/go/connector.go
+++ b/go/connector.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 // SQLConnector is the connector for AWS Athena Driver.
@@ -106,10 +107,12 @@ func (c *SQLConnector) Connect(ctx context.Context) (driver.Conn, error) {
 
 	athenaAPI := athena.New(awsSession)
 	s3API := s3.New(awsSession)
+	downloaderAPI := s3manager.NewDownloader(awsSession)
 	timeConnect := time.Since(now)
 	conn := &Connection{
 		athenaAPI: athenaAPI,
 		s3:        s3API,
+		s3mgr:     downloaderAPI,
 		connector: c,
 	}
 	c.tracer.Scope().Timer(DriverName + ".connector.connect").Record(timeConnect)

--- a/go/rows.go
+++ b/go/rows.go
@@ -167,7 +167,7 @@ func (r *Rows) openResults() error {
 		if r.config.GetScratchDir() == "" {
 			return
 		}
-		r.resultsFilename = filepath.Join(r.config.GetScratchDir(), "_athena", r.queryID)
+		r.resultsFilename = filepath.Join(r.config.GetScratchDir(), r.queryID)
 		scratchFile, err := os.Create(r.resultsFilename)
 		if err != nil {
 			return


### PR DESCRIPTION
This avoids issues when the caller doesn't consume the results fast enough and the connection is closed.