### PR TITLE
Ensure ctx is cancelled on s3manager, close files

### DIFF
--- a/go/rows.go
+++ b/go/rows.go
@@ -196,6 +196,7 @@ func (r *Rows) openResults() error {
 		if err != nil {
 			return
 		}
+		defer scratchFile.Close()
 		_, err = r.mgr.DownloadWithContext(ctx,
 			scratchFile,
 			&s3.GetObjectInput{
@@ -203,11 +204,6 @@ func (r *Rows) openResults() error {
 				Key:    aws.String(strings.TrimPrefix(resultLocation.Path, "/")),
 			},
 		)
-		if err != nil {
-			scratchFile.Close()
-			return
-		}
-		err = scratchFile.Close()
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
On lines 168-169 we set the ctx canceller but don't use that context in the `DownloadWithContext`. I _think_ that means we can end up with hanging go routines inside of the downloader implementation on a cancelled ctx